### PR TITLE
Display messages of new chats

### DIFF
--- a/client/src/context/ChatContext.jsx
+++ b/client/src/context/ChatContext.jsx
@@ -128,7 +128,7 @@ export const ChatContextProvider = ({ children, user }) => {
         }
 
         getUserChats()
-    }, [user])
+    }, [user, notifications])
 
     useEffect(() => {
         const getMessages = async() => {            


### PR DESCRIPTION
- New chats (having no previous chat history) can now receive messages and display them as and when messages are sent.